### PR TITLE
pkgname and pkgver should be both mandatory

### DIFF
--- a/pkgoutofdate.rb
+++ b/pkgoutofdate.rb
@@ -99,8 +99,8 @@ def process_pkgbuild(pkgpath)
   pkgname = sources.shift
   pkgver = sources.shift
 
-  unless pkgname or pkgver
-    log "Cannot parse #{pkgpath}, no pkgname or pkgversion" if $options.verbose
+  unless pkgname and pkgver
+    log "Cannot parse #{pkgpath}, no pkgname and pkgversion" if $options.verbose
     return
   end
 


### PR DESCRIPTION
Fixes the following error:

```
/usr/bin/pkgoutofdate:107:in `process_pkgbuild': undefined method `gsub' for nil:NilClass (NoMethodError)
        from /usr/bin/pkgoutofdate:165:in `work_thread'
        from /usr/bin/pkgoutofdate:216:in `block (2 levels) in <main>'
```